### PR TITLE
Fixed bug in Figure.js

### DIFF
--- a/template/web/src/components/figure.js
+++ b/template/web/src/components/figure.js
@@ -10,7 +10,7 @@ export default ({node}) => {
     return null
   }
 
-  const fluidProps = getFluidGatsbyImage(node.asset._ref, {maxWidth: 675}, ...clientConfig.sanity)
+  const fluidProps = getFluidGatsbyImage(node.asset._ref, {maxWidth: 675}, clientConfig.sanity)
 
   return (
     <figure className={styles.root}>


### PR DESCRIPTION
Removed spread operator in front of config.sanity, that resulted in an error when using images in rawBody elements.