### PR TITLE
Update schema naming to avoid confusion

### DIFF
--- a/template/studio/dashboardConfig.js
+++ b/template/studio/dashboardConfig.js
@@ -50,7 +50,7 @@ export default {
     {name: 'project-users', layout: {height: 'auto'}},
     {
       name: 'document-list',
-      options: {title: 'Recent projects', order: '_createdAt desc', types: ['project']},
+      options: {title: 'Recent projects', order: '_createdAt desc', types: ['sampleProject']},
       layout: {width: 'medium'}
     }
   ]

--- a/template/studio/deskStructure.js
+++ b/template/studio/deskStructure.js
@@ -2,7 +2,7 @@ import S from '@sanity/desk-tool/structure-builder'
 import MdSettings from 'react-icons/lib/md/settings'
 
 const hiddenDocTypes = listItem =>
-  !['category', 'person', 'project', 'siteSettings'].includes(listItem.getId())
+  !['category', 'person', 'sampleProject', 'siteSettings'].includes(listItem.getId())
 
 export default () =>
   S.list()
@@ -19,8 +19,8 @@ export default () =>
         .icon(MdSettings),
       S.listItem()
         .title('Projects')
-        .schemaType('project')
-        .child(S.documentTypeList('project').title('Projects')),
+        .schemaType('sampleProject')
+        .child(S.documentTypeList('sampleProject').title('Projects')),
       S.listItem()
         .title('People')
         .schemaType('person')

--- a/template/studio/deskStructure.js
+++ b/template/studio/deskStructure.js
@@ -18,9 +18,9 @@ export default () =>
         )
         .icon(MdSettings),
       S.listItem()
-        .title('Projects')
+        .title('Sample projects')
         .schemaType('sampleProject')
-        .child(S.documentTypeList('sampleProject').title('Projects')),
+        .child(S.documentTypeList('sampleProject').title('Sample projects')),
       S.listItem()
         .title('People')
         .schemaType('person')

--- a/template/studio/schemas/documents/sampleProject.js
+++ b/template/studio/schemas/documents/sampleProject.js
@@ -1,8 +1,8 @@
 import {format} from 'date-fns'
 
 export default {
-  name: 'project',
-  title: 'Project',
+  name: 'sampleProject',
+  title: 'Sample project',
   type: 'document',
   fields: [
     {
@@ -67,7 +67,7 @@ export default {
       name: 'relatedProjects',
       title: 'Related projects',
       type: 'array',
-      of: [{type: 'reference', to: {type: 'project'}}]
+      of: [{type: 'reference', to: {type: 'sampleProject'}}]
     }
   ],
   preview: {
@@ -77,7 +77,7 @@ export default {
       slug: 'slug',
       media: 'mainImage'
     },
-    prepare ({title = 'No title', publishedAt, slug = {}, media}) {
+    prepare({title = 'No title', publishedAt, slug = {}, media}) {
       const dateSegment = format(publishedAt, 'YYYY/MM')
       const path = `/${dateSegment}/${slug.current}/`
       return {

--- a/template/studio/schemas/schema.js
+++ b/template/studio/schemas/schema.js
@@ -7,7 +7,7 @@ import schemaTypes from 'all:part:@sanity/base/schema-type'
 // Document types
 import category from './documents/category'
 import person from './documents/person'
-import project from './documents/project'
+import sampleProject from './documents/sampleProject'
 import siteSettings from './documents/siteSettings'
 
 // Object types
@@ -35,7 +35,7 @@ export default createSchema({
     // in the studio.
     category,
     person,
-    project,
+    sampleProject,
     siteSettings
   ])
 })

--- a/template/web/gatsby-node.js
+++ b/template/web/gatsby-node.js
@@ -9,7 +9,7 @@ async function createProjectPages (graphql, actions, reporter) {
   const {createPage} = actions
   const result = await graphql(`
     {
-      allSanityProject(filter: {slug: {current: {ne: null}}, publishedAt: {ne: null}}) {
+      allSanitySampleProject(filter: {slug: {current: {ne: null}}, publishedAt: {ne: null}}) {
         edges {
           node {
             id
@@ -25,7 +25,7 @@ async function createProjectPages (graphql, actions, reporter) {
 
   if (result.errors) throw result.errors
 
-  const projectEdges = (result.data.allSanityProject || {}).edges || []
+  const projectEdges = (result.data.allSanitySampleProject || {}).edges || []
 
   projectEdges
     .filter(edge => !isFuture(edge.node.publishedAt))

--- a/template/web/src/pages/archive.js
+++ b/template/web/src/pages/archive.js
@@ -11,7 +11,7 @@ import {responsiveTitle1} from '../components/typography.module.css'
 
 export const query = graphql`
   query ArchivePageQuery {
-    projects: allSanityProject(
+    projects: allSanitySampleProject(
       limit: 12
       sort: {fields: [publishedAt], order: DESC}
       filter: {slug: {current: {ne: null}}, publishedAt: {ne: null}}

--- a/template/web/src/pages/index.js
+++ b/template/web/src/pages/index.js
@@ -18,7 +18,7 @@ export const query = graphql`
       description
       keywords
     }
-    projects: allSanityProject(
+    projects: allSanitySampleProject(
       limit: 6
       sort: {fields: [publishedAt], order: DESC}
       filter: {slug: {current: {ne: null}}, publishedAt: {ne: null}}

--- a/template/web/src/templates/project.js
+++ b/template/web/src/templates/project.js
@@ -8,7 +8,7 @@ import Layout from '../containers/layout'
 
 export const query = graphql`
   query ProjectTemplateQuery($id: String!) {
-    project: sanityProject(id: {eq: $id}) {
+    sampleProject: sanityProject(id: {eq: $id}) {
       id
       publishedAt
       categories {
@@ -83,7 +83,7 @@ export const query = graphql`
 
 const ProjectTemplate = props => {
   const {data, errors} = props
-  const project = data && data.project
+  const project = data && data.sampleProject
   return (
     <Layout>
       {errors && <SEO title='GraphQL Error' />}

--- a/template/web/src/templates/project.js
+++ b/template/web/src/templates/project.js
@@ -8,7 +8,7 @@ import Layout from '../containers/layout'
 
 export const query = graphql`
   query ProjectTemplateQuery($id: String!) {
-    sampleProject: sanityProject(id: {eq: $id}) {
+    sampleProject: sanitySampleProject(id: {eq: $id}) {
       id
       publishedAt
       categories {


### PR DESCRIPTION
I've updated the schema name of `project` to `sampleProject` to make it clearer that it's a generic schema name and can be changed depending on your own needs and to avoid confusion.

I've tested it and I think I managed to change it in all the right places, but if someone more familiar with this template could double check, I think that would be great.