### PR TITLE
navigate projects by category

### DIFF
--- a/template/studio/schemas/documents/category.js
+++ b/template/studio/schemas/documents/category.js
@@ -1,17 +1,40 @@
 export default {
-  name: 'category',
-  type: 'document',
-  title: 'Category',
+  name: "category",
+  type: "document",
+  title: "Category",
   fields: [
     {
-      name: 'title',
-      type: 'string',
-      title: 'Title'
+      name: "title",
+      type: "string",
+      title: "Title"
     },
     {
-      name: 'description',
-      type: 'text',
-      title: 'Description'
+      name: "slug",
+      title: "Slug",
+      type: "slug",
+      description: "Some frontend will require a slug to be set to be able to show the project",
+      options: {
+        source: "title",
+        maxLength: 96
+      }
+    },
+    {
+      name: "description",
+      type: "text",
+      title: "Description"
     }
-  ]
-}
+  ],
+  preview: {
+    select: {
+      title: "title",
+      slug: "slug"
+    },
+    prepare({ title = "No title", slug = {} }) {
+      const path = `/${slug.current}`;
+      return {
+        title,
+        subtitle: path
+      };
+    }
+  }
+};

--- a/template/web/src/components/project.js
+++ b/template/web/src/components/project.js
@@ -45,7 +45,13 @@ function Project (props) {
                 <h3 className={styles.categoriesHeadline}>Categories</h3>
                 <ul>
                   {categories.map(category => (
-                    <li key={category._id}>{category.title}</li>
+                    <li key={category._id}>
+                      {category.slug ? (
+                        <Link to={`/category/${category.slug.current}`}>{category.title}</Link>
+                      ) : (
+                        <span>{category.title}</span>
+                      )}
+                    </li>
                   ))}
                 </ul>
               </div>

--- a/template/web/src/templates/category.js
+++ b/template/web/src/templates/category.js
@@ -1,0 +1,90 @@
+import React from 'react'
+import {graphql} from 'gatsby'
+import Container from '../components/container'
+import GraphQLErrorList from '../components/graphql-error-list'
+import SEO from '../components/seo'
+import Layout from '../containers/layout'
+import {
+  mapEdgesToNodes,
+  filterOutDocsWithoutSlugs,
+  filterOutDocsPublishedInTheFuture
+} from '../lib/helpers'
+import ProjectPreviewGrid from '../components/project-preview-grid'
+
+export const query = graphql`
+  query CategoryTemplateQuery($id: String!) {
+    projects: allSanityProject(
+      sort: {fields: [publishedAt], order: DESC}
+      filter: {
+        categories: {elemMatch: {id: {eq: $id}}}
+        slug: {current: {ne: null}}
+        publishedAt: {ne: null}
+      }
+    ) {
+      edges {
+        node {
+          id
+          mainImage {
+            crop {
+              _key
+              _type
+              top
+              bottom
+              left
+              right
+            }
+            hotspot {
+              _key
+              _type
+              x
+              y
+              height
+              width
+            }
+            asset {
+              _id
+            }
+            alt
+          }
+          title
+          _rawExcerpt
+          slug {
+            current
+          }
+        }
+      }
+    }
+  }
+`
+
+const ProjectTemplate = props => {
+  const {data, errors, pageContext} = props
+
+  const projectNodes = (data || {}).projects
+    ? mapEdgesToNodes(data.projects)
+      .filter(filterOutDocsWithoutSlugs)
+      .filter(filterOutDocsPublishedInTheFuture)
+    : []
+
+  const {category} = pageContext
+
+  return (
+    <Layout>
+      {errors && <SEO title='GraphQL Error' />}
+      {category && <SEO title={category.title || 'Untitled'} />}
+
+      {errors && (
+        <Container>
+          <GraphQLErrorList errors={errors} />
+        </Container>
+      )}
+      <Container>
+        {projectNodes && (
+          <ProjectPreviewGrid title={`${category.title} projects`} nodes={projectNodes} />
+        )}
+      </Container>
+    </Layout>
+  )
+}
+
+export default ProjectTemplate

--- a/template/web/src/templates/project.js
+++ b/template/web/src/templates/project.js
@@ -14,6 +14,9 @@ export const query = graphql`
       categories {
         _id
         title
+        slug {
+          current
+        }
       }
       relatedProjects {
         title


### PR DESCRIPTION
New slug field added to category schema in studio. New category template to template out pages based on category. Function `createCategoryPages` added to `gatsby-node.js` to create pages for each category.